### PR TITLE
adiciona .gitignore para ignorar virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#virtual environments
+venv/


### PR DESCRIPTION
Adiciona um `.gitignore` básico, neste momento apenas para ignorar a pasta do `virtual environment`.